### PR TITLE
Adapt minimization to modes

### DIFF
--- a/src/apps/em/VA13Solver.cpp
+++ b/src/apps/em/VA13Solver.cpp
@@ -27,7 +27,7 @@ using std::endl;
 as::VA13Solver::Options as::VA13Solver::settings;
 
 extern "C" void minfor_(void* FortranSmuggler_ptr, int const& maxFunEval,
-		double const* state);
+		double const* state, int const& numModesRec, int const& numModesLig);
 
 namespace as {
 
@@ -41,7 +41,10 @@ void VA13Solver::run(push_type& ca) {
 		state_array[i] = state(i);
 	}
 
-	minfor_(&smuggler, settings.maxFunEval, state_array);
+	minfor_(&smuggler, settings.maxFunEval, 
+            state_array,
+            Common_Modes::numModesRec,
+			Common_Modes::numModesLig);
 }
 
 } // namespace

--- a/src/apps/em/meta.h
+++ b/src/apps/em/meta.h
@@ -115,7 +115,6 @@ public:
 		ObjGrad objGrad;
 		objGrad.obj = enGrad.E;
 		objGrad.grad = Vector(6);
-		// for ATTRACT multiply gradients by -1.0
 		objGrad.grad  << -enGrad.ang.x, -enGrad.ang.y,  -enGrad.ang.z,
 						 -enGrad.pos.x, -enGrad.pos.y , -enGrad.pos.z;
 		return objGrad;
@@ -137,26 +136,41 @@ public:
 
 
 // Typesconverter for modes
+
 template<typename REAL>
 class TypesConverter<DOF_6D_Modes<REAL>, Vector> {
 public:
 	static DOF_6D_Modes<REAL> toFirst(Vector const& vec) {
 		DOF_6D_Modes<REAL> dof;
-		dof.ang.x = vec(0);
-		dof.ang.y = vec(1);
-		dof.ang.z = vec(2);
-		dof.pos.x = vec(3);
-		dof.pos.y = vec(4);
-		dof.pos.z = vec(5);
-		for(int mode=0;mode< dof.numModes; mode++){dof.modes[mode]=vec(6+mode);}
+		dof._6D.ang.x = vec(0);
+		dof._6D.ang.y = vec(1);
+		dof._6D.ang.z = vec(2);
+		dof._6D.pos.x = vec(3);
+		dof._6D.pos.y = vec(4);
+		dof._6D.pos.z = vec(5);
+		for(int mode=0;mode< Common_Modes::numModesRec; mode++){
+			dof.modesRec[mode]=vec(6 + mode);
+		}
+		for(int mode=0;mode< Common_Modes::numModesLig; mode++){
+			dof.modesLig[mode]=vec(6 + mode + Common_Modes::numModesRec);
+		}
 		return dof;
 	}
 
 	static Vector toSecond(DOF_6D_Modes<REAL> const& dof) {
-		Vector vec(6+dof.numModes);
-		vec  << dof.ang.x, dof.ang.y, dof.ang.z,
-				dof.pos.x, dof.pos.y , dof.pos.z;
-		for(int mode=0;mode< dof.numModes; mode++){vec  << dof.modes[mode];}
+		Vector vec(DOF_MAX_NUMBER);
+		vec(0) = dof._6D.ang.x;
+		vec(1) = dof._6D.ang.y;
+		vec(2) = dof._6D.ang.z;
+		vec(3) = dof._6D.pos.x;
+		vec(4) = dof._6D.pos.y;
+		vec(5) = dof._6D.pos.z;
+		for(int mode=0;mode< Common_Modes::numModesRec; mode++){
+			vec(6 + mode)  = dof.modesRec[mode];
+		}
+		for(int mode=0;mode< Common_Modes::numModesLig; mode++){
+			vec(6 + Common_Modes::numModesRec + mode)  = dof.modesLig[mode];
+		}
 		return vec;
 	}
 };
@@ -178,25 +192,39 @@ class TypesConverter<Result_6D_Modes<REAL>, ObjGrad> {
 public:
 	static Result_6D_Modes<REAL> toFirst(ObjGrad const& objGrad) {
 		Result_6D_Modes<REAL> enGrad;
-		enGrad.E = objGrad.obj;
-		enGrad.ang.x = objGrad.grad(0);
-		enGrad.ang.y = objGrad.grad(1);
-		enGrad.ang.z = objGrad.grad(2);
-		enGrad.pos.x = objGrad.grad(3);
-		enGrad.pos.y = objGrad.grad(4);
-		enGrad.pos.z = objGrad.grad(5);
-		for(int mode=0;mode< enGrad.numModes; mode++){	enGrad.modes[mode] = objGrad.grad(6+mode);}
+		enGrad._6D.E = objGrad.obj;
+		enGrad._6D.ang.x = objGrad.grad(0);
+		enGrad._6D.ang.y = objGrad.grad(1);
+		enGrad._6D.ang.z = objGrad.grad(2);
+		enGrad._6D.pos.x = objGrad.grad(3);
+		enGrad._6D.pos.y = objGrad.grad(4);
+		enGrad._6D.pos.z = objGrad.grad(5);
+		for(int mode=0;mode< Common_Modes::numModesRec; mode++){
+			enGrad.modesRec[mode] = objGrad.grad(6 + mode);
+		}
+		for(int mode=0;mode< Common_Modes::numModesLig; mode++){
+			enGrad.modesLig[mode] = objGrad.grad(6 + mode + Common_Modes::numModesRec);
+		}
 		return enGrad;
 	}
 
 	static ObjGrad toSecond (Result_6D_Modes<REAL> const& enGrad) {
 		ObjGrad objGrad;
-		objGrad.obj = enGrad.E;
-		objGrad.grad = Vector(6+enGrad.numModes);
-		// for ATTRACT multiply gradients by -1.0
-		objGrad.grad  << -enGrad.ang.x, -enGrad.ang.y,  -enGrad.ang.z,
-						 -enGrad.pos.x, -enGrad.pos.y , -enGrad.pos.z;
-		for(int mode=0;mode< enGrad.numModes; mode++){objGrad.grad  << -enGrad.modes[mode];}
+		objGrad.obj = enGrad._6D.E;
+		objGrad.grad = Vector( DOF_MAX_NUMBER );
+		objGrad.grad(0) = -enGrad._6D.ang.x;
+		objGrad.grad(1) = -enGrad._6D.ang.y;
+		objGrad.grad(2) = -enGrad._6D.ang.z;
+		objGrad.grad(3) = -enGrad._6D.pos.x;
+		objGrad.grad(4) = -enGrad._6D.pos.y;
+		objGrad.grad(5) = -enGrad._6D.pos.z;
+
+		for(int mode=0;mode< Common_Modes::numModesRec; mode++){
+			objGrad.grad(6 + mode)  = -enGrad.modesRec[mode];
+		}
+		for(int mode=0;mode< Common_Modes::numModesLig; mode++){
+			objGrad.grad(6 + Common_Modes::numModesRec +  mode)  = -enGrad.modesLig[mode];
+		}
 		return objGrad;
 	}
 };

--- a/src/apps/em/minfor.f
+++ b/src/apps/em/minfor.f
@@ -1,6 +1,6 @@
       subroutine minfor(
-     1 smug, ivmax, x
-     2 )
+     1 smug, ivmax, x,
+     2 numModesRec, numModesLig)
 c
 c  variable metric minimizer (Harwell subroutine lib.  as in Jumna with modifications)
 c     minimizes a single structure
@@ -14,7 +14,8 @@ c     Parameters
       integer ivmax
       real*8 x
       dimension x(6)
-
+      
+      integer numModesRec, numModesLig
 c     Local variables
       real*8  gesa
       integer i,k,ir,isfv,itr,nfun,np,jn

--- a/src/apps/em/minfor.f
+++ b/src/apps/em/minfor.f
@@ -13,8 +13,8 @@ c     Parameters
       type(c_ptr) smug
       integer ivmax
       real*8 x
-      dimension x(6)
-      
+      dimension x(46)
+
       integer numModesRec, numModesLig
 c     Local variables
       real*8  gesa
@@ -23,15 +23,15 @@ c     Local variables
       real*8 fb
       
       real*8 h,g,ga,gb,xaa,xbb,d,step,stepbd,steplb,stmin
-      dimension h(6*6)
-      dimension g(6),ga(6),gb(6),w(6)
-      dimension xaa(6), xbb(6), d(6)
+      dimension h(46*46)
+      dimension g(46),ga(46),gb(46),w(46)
+      dimension xaa(46), xbb(46), d(46)
 
       integer, parameter:: ERROR_UNIT = 0
 
       xnull=0.0d0
       dga=xnull
-      jn = 6
+      jn = 6 + numModesRec + numModesLig
 
       do i=1,jn
        ga(i)=xnull
@@ -106,8 +106,12 @@ c     test whether func has been called ivmax times
 c     calculate another function value and gradient
       
 c     make an Euler rotation + tranlation of ligand center
-      do i=1,jn
+      do i=1,6
        xbb(i)=xaa(i)+c*d(i)
+      enddo
+
+      do i=7,jn
+        xbb(i)=xaa(i)-c*d(i)
       enddo
 
       call energy_for_fortran_to_call(smug, xbb, fb, gb)


### PR DESCRIPTION
The solver VA13 was adapted to the use of modes. This includes the type conversion from Eigen to internal types, as well as the minimization if minfor.f in the degrees of freedoms when using modes